### PR TITLE
feat(fe): P0-1 Create Payment + Result (Issue #8)

### DIFF
--- a/workspace/fe/src/app/transactions/[id]/result/page.tsx
+++ b/workspace/fe/src/app/transactions/[id]/result/page.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import StepIndicator from '../../../../components/business/transactions/StepIndicator'
+import PaymentResultCard from '../../../../components/business/transactions/PaymentResult'
+import { ToastContainer, useToast } from '../../../../components/design'
+import { usePaymentResult } from '../../../../hooks/usePaymentResult'
+import type { CreatePaymentPayload } from '../../../../components/business/transactions/types'
+
+export default function TransactionResultPage() {
+  const params = useParams()
+  const router = useRouter()
+  const { toasts, close, success } = useToast()
+
+  const id = Array.isArray(params.id) ? params.id[0] : params.id
+  const decodedId = id ? decodeURIComponent(id) : ''
+
+  const { loading, error, result, countdownSeconds, timedOut, retry, manualRefresh } = usePaymentResult({
+    id: decodedId,
+  })
+
+  const steps = useMemo(
+    () => [
+      { key: 'details', label: 'Payment Details' },
+      { key: 'review', label: 'Review & Confirm' },
+      { key: 'done', label: 'Done' },
+    ],
+    [],
+  )
+
+  const current = result?.status === 'pending' ? 2 : 2
+  const completed = useMemo(() => {
+    if (!result) return [true, true, false]
+    if (result.status === 'pending') return [true, true, false]
+    return [true, true, true]
+  }, [result])
+
+  return (
+    <div className="flex flex-col gap-[var(--space-6)]">
+      <ToastContainer toasts={toasts} onClose={close} />
+
+      <StepIndicator steps={steps} current={current} completed={completed} />
+
+      <PaymentResultCard
+        loading={loading}
+        error={error}
+        result={result}
+        countdownSeconds={countdownSeconds}
+        timedOut={timedOut}
+        onRetryFetch={retry}
+        onManualRefresh={manualRefresh}
+        onCopyId={(txId) => {
+          navigator.clipboard.writeText(txId)
+          success('Copied', 'Transaction ID copied')
+        }}
+        onNavigateView={(txId) => router.push(`/transactions/${encodeURIComponent(txId)}`)}
+        onNavigateList={() => router.push('/transactions')}
+        onNavigateNew={({ prefill } = {}) => {
+          if (prefill) {
+            sessionStorage.setItem('createPaymentPrefill', JSON.stringify(prefill as CreatePaymentPayload))
+            router.push('/transactions/new?prefill=1')
+          } else {
+            router.push('/transactions/new')
+          }
+        }}
+      />
+    </div>
+  )
+}
+

--- a/workspace/fe/src/app/transactions/new/page.tsx
+++ b/workspace/fe/src/app/transactions/new/page.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import { ToastContainer, useToast } from '../../../components/design'
+import StepIndicator from '../../../components/business/transactions/StepIndicator'
+import PaymentForm from '../../../components/business/transactions/PaymentForm'
+import PaymentReview from '../../../components/business/transactions/PaymentReview'
+import { useCreatePayment } from '../../../hooks/useCreatePayment'
+
+export default function TransactionsCreatePaymentPage() {
+  const router = useRouter()
+  const { toasts, close, error: toastError } = useToast()
+
+  const {
+    step,
+    value,
+    setValue,
+    merchant,
+    merchants,
+    merchantsLoading,
+    merchantsError,
+    retryMerchants,
+    errors,
+    validateField,
+    dirty,
+    submitting,
+    cancelConfirmOpen,
+    openCancel,
+    closeCancel,
+    confirmCancel,
+    continueToReview,
+    backToEdit,
+    submit,
+  } = useCreatePayment()
+
+  const steps = useMemo(
+    () => [
+      { key: 'details', label: 'Payment Details' },
+      { key: 'review', label: 'Review & Confirm' },
+      { key: 'done', label: 'Done' },
+    ],
+    [],
+  )
+
+  const handleSubmit = async () => {
+    try {
+      await submit()
+    } catch (e) {
+      toastError('Failed to create payment', 'Please try again.')
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-[var(--space-6)]">
+      <ToastContainer toasts={toasts} onClose={close} />
+
+      {/* Breadcrumb */}
+      <nav
+        aria-label="Breadcrumb"
+        className="mb-[var(--space-4)] flex items-center gap-2 text-[var(--font-sm)] text-[var(--color-gray-500)]"
+      >
+        <button
+          type="button"
+          onClick={() => router.push('/transactions')}
+          className="text-[var(--color-primary-500)] hover:text-[var(--color-primary-600)]"
+        >
+          Transactions
+        </button>
+        <span className="text-[var(--color-gray-300)]">/</span>
+        <span className="text-[var(--color-gray-700)]">Create Payment</span>
+      </nav>
+
+      {/* Page Header */}
+      <h1 className="mb-[var(--space-6)] text-[var(--font-2xl)] font-semibold text-[var(--color-gray-900)]">
+        Create Payment
+      </h1>
+
+      <StepIndicator steps={steps} current={step} />
+
+      <div className="w-full xl:mx-auto xl:max-w-[720px]">
+        {step === 0 ? (
+          <PaymentForm
+            value={value}
+            merchants={merchants}
+            merchantsLoading={merchantsLoading}
+            merchantsError={merchantsError}
+            onRetryMerchants={retryMerchants}
+            disabled={submitting}
+            errors={errors}
+            dirty={dirty}
+            onChange={setValue}
+            onValidateField={validateField}
+            onCancel={cancelConfirmOpen ? closeCancel : openCancel}
+            onConfirmCancel={confirmCancel}
+            cancelConfirmOpen={cancelConfirmOpen}
+            onContinue={continueToReview}
+          />
+        ) : (
+          <PaymentReview
+            value={value}
+            merchant={merchant}
+            disabled={submitting}
+            dirty={dirty}
+            onBack={backToEdit}
+            onCancel={cancelConfirmOpen ? closeCancel : openCancel}
+            onConfirmCancel={confirmCancel}
+            cancelConfirmOpen={cancelConfirmOpen}
+            onSubmit={handleSubmit}
+            submitting={submitting}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/workspace/fe/src/app/transactions/page.tsx
+++ b/workspace/fe/src/app/transactions/page.tsx
@@ -121,9 +121,12 @@ export default function TransactionsListPage() {
       {/* Page Header */}
       <div className="flex items-center justify-between">
         <h1 className="text-[var(--font-2xl)] font-semibold text-[var(--color-gray-900)]">Transactions</h1>
-        <Button variant="secondary" icon={DownloadIcon} onClick={exportCsv} loading={exporting}>
-          Export
-        </Button>
+        <div className="flex items-center gap-[var(--space-3)]">
+          <Button onClick={() => router.push('/transactions/new')}>Create Payment</Button>
+          <Button variant="secondary" icon={DownloadIcon} onClick={exportCsv} loading={exporting}>
+            Export
+          </Button>
+        </div>
       </div>
 
       {/* Filter Bar */}
@@ -228,4 +231,3 @@ export default function TransactionsListPage() {
     </div>
   )
 }
-

--- a/workspace/fe/src/components/business/transactions/PaymentForm.tsx
+++ b/workspace/fe/src/components/business/transactions/PaymentForm.tsx
@@ -1,0 +1,489 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Button, Dialog, Input, Select, Textarea } from '../../design'
+import type { SelectOption } from '../../design'
+import type {
+  CardDetails,
+  CreatePaymentPayload,
+  Merchant,
+  MetadataItem,
+  PaymentMethod,
+} from './types'
+
+export type PaymentFormErrors = Partial<Record<keyof CreatePaymentPayload | 'card.number' | 'card.expiry' | 'card.cvv' | 'card.cardholder' | 'metadata', string>>
+
+export interface PaymentFormProps {
+  value: CreatePaymentPayload
+  merchants: Merchant[]
+  merchantsLoading: boolean
+  merchantsError?: string | null
+  disabled?: boolean
+  errors?: PaymentFormErrors
+  dirty?: boolean
+  onChange: (next: CreatePaymentPayload) => void
+  onValidateField?: (field: string) => void
+  onRetryMerchants?: () => void
+  onCancel: () => void
+  onConfirmCancel: () => void
+  cancelConfirmOpen: boolean
+  onContinue: () => void
+}
+
+const PlusIcon = (
+  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+  </svg>
+)
+
+const TrashIcon = (
+  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3m-4 0h14" />
+  </svg>
+)
+
+function formatCardNumber(raw: string) {
+  const digits = raw.replace(/\D/g, '').slice(0, 19)
+  const parts: string[] = []
+  for (let i = 0; i < digits.length; i += 4) parts.push(digits.slice(i, i + 4))
+  return parts.join(' ')
+}
+
+function formatExpiry(raw: string) {
+  const digits = raw.replace(/\D/g, '').slice(0, 4)
+  if (digits.length <= 2) return digits
+  return `${digits.slice(0, 2)}/${digits.slice(2)}`
+}
+
+function detectBrand(num: string): 'visa' | 'mastercard' | 'amex' | 'unknown' {
+  const n = num.replace(/\s/g, '')
+  if (/^4\d{0,}$/.test(n)) return 'visa'
+  if (/^(5[1-5]|2[2-7])\d{0,}$/.test(n)) return 'mastercard'
+  if (/^3[47]\d{0,}$/.test(n)) return 'amex'
+  return 'unknown'
+}
+
+function BrandIcon({ brand }: { brand: ReturnType<typeof detectBrand> }) {
+  if (brand === 'unknown') return null
+  const label = brand === 'amex' ? 'Amex' : brand === 'mastercard' ? 'Mastercard' : 'Visa'
+  return (
+    <span
+      className="text-[12px] font-medium text-[var(--color-text-tertiary)]"
+      aria-label={label}
+    >
+      {label}
+    </span>
+  )
+}
+
+function getCurrencySymbol(code: string) {
+  const map: Record<string, string> = { USD: '$', EUR: '€', GBP: '£', CNY: '¥', JPY: '¥' }
+  return map[code] ?? '$'
+}
+
+export function PaymentForm({
+  value,
+  merchants,
+  merchantsLoading,
+  merchantsError,
+  disabled = false,
+  errors,
+  dirty,
+  onChange,
+  onValidateField,
+  onRetryMerchants,
+  onCancel,
+  onConfirmCancel,
+  cancelConfirmOpen,
+  onContinue,
+}: PaymentFormProps) {
+  const selectedMerchant = useMemo(
+    () => merchants.find((m) => m.id === value.merchantId) ?? null,
+    [merchants, value.merchantId],
+  )
+
+  /* ── Merchant search debounce (300ms) ── */
+  const [merchantSearch, setMerchantSearch] = useState('')
+  const [merchantSearchDebounced, setMerchantSearchDebounced] = useState('')
+  useEffect(() => {
+    const t = window.setTimeout(() => setMerchantSearchDebounced(merchantSearch), 300)
+    return () => window.clearTimeout(t)
+  }, [merchantSearch])
+
+  const merchantOptions = useMemo<SelectOption[]>(() => {
+    const kw = merchantSearchDebounced.trim().toLowerCase()
+    const filtered = kw
+      ? merchants.filter(
+          (m) => m.name.toLowerCase().includes(kw) || m.id.toLowerCase().includes(kw),
+        )
+      : merchants
+
+    return filtered.map((m) => ({
+      value: m.id,
+      label: `${m.name}  (${m.id})`,
+    }))
+  }, [merchants, merchantSearchDebounced])
+
+  const currencyOptions = useMemo<SelectOption[]>(() => {
+    const list = selectedMerchant?.currencies?.length ? selectedMerchant.currencies : ['USD']
+    return list.map((c) => ({ value: c, label: c }))
+  }, [selectedMerchant])
+
+  const methodOptions: SelectOption[] = [
+    { value: 'card', label: 'Card' },
+    { value: 'bank_transfer', label: 'Bank Transfer' },
+    { value: 'e_wallet', label: 'E-Wallet' },
+  ]
+
+  const amountStr = useMemo(() => {
+    if (!value.amountCents) return ''
+    return (value.amountCents / 100).toFixed(2)
+  }, [value.amountCents])
+
+  const brand = detectBrand(value.card?.number ?? '')
+
+  const setCard = (next: Partial<CardDetails>) => {
+    const current: CardDetails = value.card ?? { number: '', expiry: '', cvv: '', cardholder: '' }
+    onChange({ ...value, card: { ...current, ...next } })
+  }
+
+  const updateMetadata = (items: MetadataItem[]) => {
+    onChange({ ...value, metadata: items })
+  }
+
+  const canAddMetadata = value.metadata.length < 10
+
+  return (
+    <div className="flex flex-col gap-[var(--space-6)]">
+      {/* Form Card */}
+      <section className="rounded-[var(--radius-lg)] bg-[var(--color-white)] p-[var(--space-6)] shadow-[var(--shadow-sm)]">
+        <h2 className="mb-[var(--space-4)] text-[var(--font-lg)] font-semibold text-[var(--color-gray-900)]">
+          Payment Details
+        </h2>
+
+        <form aria-label="Create payment form" className="flex flex-col gap-[var(--space-4)]">
+          {/* Merchant */}
+          <div className="flex flex-col gap-1">
+            <label className="text-[var(--font-sm)] font-medium text-[var(--color-gray-700)]">
+              Merchant <span className="text-[var(--color-error)]">*</span>
+            </label>
+            <Select
+              variant="searchable"
+              fullWidth
+              placeholder={merchantsLoading ? 'Loading merchants…' : 'Select merchant'}
+              options={merchantOptions}
+              value={value.merchantId}
+              onChange={(v) => {
+                const merchantId = String(v ?? '')
+                const m = merchants.find((x) => x.id === merchantId)
+                onChange({
+                  ...value,
+                  merchantId,
+                  currency: m?.defaultCurrency ?? value.currency,
+                })
+              }}
+              loading={merchantsLoading}
+              error={!!errors?.merchantId}
+              errorMessage={errors?.merchantId}
+              emptyText={merchantsError ? 'Failed to load merchants' : 'No merchants found'}
+              onSearch={(kw) => setMerchantSearch(kw)}
+              disabled={disabled}
+            />
+            {merchantsError && onRetryMerchants && (
+              <button
+                type="button"
+                onClick={onRetryMerchants}
+                className="w-fit text-[var(--font-xs)] text-[var(--color-primary-600)] hover:underline"
+                disabled={disabled}
+              >
+                Retry
+              </button>
+            )}
+          </div>
+
+          {/* Amount composite */}
+          <div className="flex flex-col gap-1">
+            <label className="text-[var(--font-sm)] font-medium text-[var(--color-gray-700)]">
+              Amount <span className="text-[var(--color-error)]">*</span>
+            </label>
+            <div className="flex flex-col gap-2 md:flex-row md:items-center">
+              <div className="flex w-full overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border-primary)] bg-[var(--color-bg-container)] md:flex-1">
+                <span className="flex h-10 w-10 items-center justify-center border-r border-[var(--color-border-primary)] bg-[var(--color-gray-50)] text-[var(--color-gray-500)]">
+                  {getCurrencySymbol(value.currency)}
+                </span>
+                <input
+                  value={amountStr}
+                  disabled={disabled}
+                  onChange={(e) => {
+                    const nextRaw = e.target.value
+                    const cleaned = nextRaw.replace(/[^\d.]/g, '')
+                    const num = Number(cleaned)
+                    if (Number.isNaN(num)) {
+                      onChange({ ...value, amountCents: 0 })
+                      return
+                    }
+                    const cents = Math.round(num * 100)
+                    onChange({ ...value, amountCents: cents })
+                  }}
+                  onBlur={() => onValidateField?.('amountCents')}
+                  inputMode="decimal"
+                  className={[
+                    'h-10 flex-1 bg-transparent px-3 text-right font-mono text-[16px] outline-none',
+                    errors?.amountCents ? 'ring-2 ring-[var(--color-error-light)]' : '',
+                    disabled ? 'cursor-not-allowed text-[var(--color-text-disabled)]' : '',
+                  ].join(' ')}
+                  aria-invalid={!!errors?.amountCents || undefined}
+                />
+              </div>
+              <div className="w-full md:w-20">
+                <Select
+                  fullWidth
+                  options={currencyOptions}
+                  value={value.currency}
+                  onChange={(v) => onChange({ ...value, currency: String(v ?? '') })}
+                  disabled={disabled || !selectedMerchant}
+                  error={!!errors?.currency}
+                  errorMessage={errors?.currency}
+                />
+              </div>
+            </div>
+            {errors?.amountCents && (
+              <span className="text-[var(--font-xs)] text-[var(--color-error)]" role="alert">
+                {errors.amountCents}
+              </span>
+            )}
+          </div>
+
+          {/* Reference + Description */}
+          <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2">
+            <Input
+              fullWidth
+              label="Reference ID"
+              placeholder="Auto or manual"
+              value={value.referenceId}
+              disabled={disabled}
+              onChange={(e) => onChange({ ...value, referenceId: e.target.value })}
+              onBlur={() => onValidateField?.('referenceId')}
+              error={!!errors?.referenceId}
+              errorMessage={errors?.referenceId}
+            />
+            <div className="md:col-span-1" />
+          </div>
+          <Textarea
+            fullWidth
+            label="Description"
+            placeholder="Payment description"
+            value={value.description}
+            disabled={disabled}
+            onChange={(e) => onChange({ ...value, description: e.target.value })}
+            onBlur={() => onValidateField?.('description')}
+            error={!!errors?.description}
+            errorMessage={errors?.description}
+          />
+
+          <div className="my-[var(--space-6)] h-px w-full bg-[var(--color-gray-100)]" />
+
+          <div className="text-[var(--font-sm)] font-medium uppercase tracking-[0.05em] text-[var(--color-gray-500)]">
+            Payment Method
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-[var(--font-sm)] font-medium text-[var(--color-gray-700)]">
+              Method <span className="text-[var(--color-error)]">*</span>
+            </label>
+          <Select
+            fullWidth
+            options={methodOptions}
+            value={value.method}
+            onChange={(v) => onChange({ ...value, method: v as PaymentMethod })}
+            disabled={disabled}
+            error={!!errors?.method}
+            errorMessage={errors?.method}
+          />
+          </div>
+
+          {/* Card details (conditional) */}
+          <div
+            className={[
+              'overflow-hidden transition-all duration-200 ease-in-out',
+              value.method === 'card' ? 'max-h-[520px] opacity-100' : 'max-h-0 opacity-0',
+            ].join(' ')}
+            aria-hidden={value.method !== 'card'}
+          >
+            <div className="mt-[var(--space-4)] flex flex-col gap-[var(--space-4)]">
+              <div className="text-[var(--font-sm)] font-medium uppercase tracking-[0.05em] text-[var(--color-gray-500)]">
+                Card Details
+              </div>
+              <Input
+                fullWidth
+                label="Card Number *"
+                placeholder="•••• •••• •••• ••••"
+                value={value.card?.number ?? ''}
+                disabled={disabled}
+                onChange={(e) => setCard({ number: formatCardNumber(e.target.value) })}
+                onBlur={() => onValidateField?.('card.number')}
+                error={!!errors?.['card.number']}
+                errorMessage={errors?.['card.number']}
+                inputMode="numeric"
+                autoComplete="cc-number"
+                iconRight={<BrandIcon brand={brand} />}
+              />
+              <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-3">
+                <Input
+                  fullWidth
+                  label="Expiry *"
+                  placeholder="MM/YY"
+                  value={value.card?.expiry ?? ''}
+                  disabled={disabled}
+                  onChange={(e) => setCard({ expiry: formatExpiry(e.target.value) })}
+                  onBlur={() => onValidateField?.('card.expiry')}
+                  error={!!errors?.['card.expiry']}
+                  errorMessage={errors?.['card.expiry']}
+                  inputMode="numeric"
+                  autoComplete="cc-exp"
+                />
+                <Input
+                  fullWidth
+                  label="CVV *"
+                  placeholder="•••"
+                  type="password"
+                  value={value.card?.cvv ?? ''}
+                  disabled={disabled}
+                  onChange={(e) => setCard({ cvv: e.target.value.replace(/\D/g, '').slice(0, 4) })}
+                  onBlur={() => onValidateField?.('card.cvv')}
+                  error={!!errors?.['card.cvv']}
+                  errorMessage={errors?.['card.cvv']}
+                  inputMode="numeric"
+                  autoComplete="cc-csc"
+                />
+                <Input
+                  fullWidth
+                  label="Cardholder *"
+                  placeholder="Name on card"
+                  value={value.card?.cardholder ?? ''}
+                  disabled={disabled}
+                  onChange={(e) => setCard({ cardholder: e.target.value })}
+                  onBlur={() => onValidateField?.('card.cardholder')}
+                  error={!!errors?.['card.cardholder']}
+                  errorMessage={errors?.['card.cardholder']}
+                  autoComplete="cc-name"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="my-[var(--space-6)] h-px w-full bg-[var(--color-gray-100)]" />
+
+          <div className="flex items-center justify-between">
+            <div className="text-[var(--font-sm)] font-medium uppercase tracking-[0.05em] text-[var(--color-gray-500)]">
+              Metadata (Optional)
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={PlusIcon}
+              onClick={() => {
+                if (!canAddMetadata) return
+                updateMetadata([...value.metadata, { key: '', value: '' }])
+              }}
+              disabled={disabled || !canAddMetadata}
+            >
+              Add metadata
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {value.metadata.length === 0 && (
+              <div className="text-[var(--font-xs)] text-[var(--color-gray-500)]">No metadata</div>
+            )}
+            {value.metadata.map((row, idx) => (
+              <div key={idx} className="flex flex-col gap-2 md:flex-row md:items-center">
+                <div className="md:w-[40%]">
+                  <Input
+                    fullWidth
+                    placeholder="key"
+                    value={row.key}
+                    disabled={disabled}
+                    onChange={(e) => {
+                      const next = [...value.metadata]
+                      next[idx] = { ...next[idx], key: e.target.value }
+                      updateMetadata(next)
+                    }}
+                    onBlur={() => onValidateField?.('metadata')}
+                  />
+                </div>
+                <div className="md:w-[50%]">
+                  <Input
+                    fullWidth
+                    placeholder="value"
+                    value={row.value}
+                    disabled={disabled}
+                    onChange={(e) => {
+                      const next = [...value.metadata]
+                      next[idx] = { ...next[idx], value: e.target.value }
+                      updateMetadata(next)
+                    }}
+                    onBlur={() => onValidateField?.('metadata')}
+                  />
+                </div>
+                <div className="md:w-[10%] md:flex md:justify-end">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const next = value.metadata.filter((_, i) => i !== idx)
+                      updateMetadata(next)
+                    }}
+                    disabled={disabled}
+                    className="flex h-10 w-10 items-center justify-center rounded-[var(--radius-md)] text-[var(--color-gray-400)] hover:bg-[var(--color-gray-50)] hover:text-[var(--color-error)] disabled:opacity-50 disabled:cursor-not-allowed"
+                    aria-label="Delete metadata row"
+                  >
+                    {TrashIcon}
+                  </button>
+                </div>
+              </div>
+            ))}
+            {errors?.metadata && (
+              <span className="text-[var(--font-xs)] text-[var(--color-error)]" role="alert">
+                {errors.metadata}
+              </span>
+            )}
+          </div>
+        </form>
+      </section>
+
+      {/* Actions */}
+      <div className="flex justify-end gap-[var(--space-3)]">
+        <Button variant="ghost" onClick={onCancel} disabled={disabled}>
+          Cancel
+        </Button>
+        <Button onClick={onContinue} disabled={disabled}>
+          Continue to Review →
+        </Button>
+      </div>
+
+      {/* Cancel confirmation */}
+      <Dialog
+        open={cancelConfirmOpen}
+        onClose={onCancel}
+        variant="confirm"
+        title="Discard changes?"
+        footer={
+          <>
+            <Button variant="ghost" onClick={onCancel}>
+              Keep editing
+            </Button>
+            <Button variant="danger" onClick={onConfirmCancel}>
+              Discard
+            </Button>
+          </>
+        }
+      >
+        <div className="text-[var(--font-base)] text-[var(--color-text-secondary)]">
+          {dirty ? 'You have unsaved changes. Are you sure you want to discard them?' : 'Discard this payment draft?'}
+        </div>
+      </Dialog>
+    </div>
+  )
+}
+
+export default PaymentForm

--- a/workspace/fe/src/components/business/transactions/PaymentResult.tsx
+++ b/workspace/fe/src/components/business/transactions/PaymentResult.tsx
@@ -1,0 +1,353 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Button, Empty, Skeleton } from '../../design'
+import type { PaymentResult, PaymentResultStatus } from './types'
+
+const CheckIcon = (
+  <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+  </svg>
+)
+
+const XIcon = (
+  <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+)
+
+const ClockIcon = (
+  <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+)
+
+const CopyIcon = (
+  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
+    />
+  </svg>
+)
+
+function formatMoney(cents: number, currency: string) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(cents / 100)
+}
+
+function formatDateTime(iso: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short',
+  }).format(new Date(iso))
+}
+
+function methodLabel(r: PaymentResult) {
+  if (r.method === 'card') {
+    const num = r.payload?.card?.number ?? ''
+    const last4 = num.replace(/\D/g, '').slice(-4)
+    return last4 ? `Card •••• ${last4}` : 'Card'
+  }
+  return r.method === 'bank_transfer' ? 'Bank Transfer' : 'E-Wallet'
+}
+
+export interface PaymentResultProps {
+  loading: boolean
+  error?: string | null
+  result?: PaymentResult | null
+  countdownSeconds?: number
+  timedOut?: boolean
+  onManualRefresh?: () => void
+  onRetryFetch?: () => void
+  onCopyId?: (id: string) => void
+  onNavigateView?: (id: string) => void
+  onNavigateList?: () => void
+  onNavigateNew?: (opts?: { prefill?: any }) => void
+}
+
+export function PaymentResultCard({
+  loading,
+  error,
+  result,
+  countdownSeconds,
+  timedOut,
+  onManualRefresh,
+  onRetryFetch,
+  onCopyId,
+  onNavigateView,
+  onNavigateList,
+  onNavigateNew,
+}: PaymentResultProps) {
+  const status: PaymentResultStatus | null = result?.status ?? null
+
+  const statusCfg = useMemo(() => {
+    if (status === 'success') return { title: 'Payment Successful', color: 'var(--color-success)', bg: 'var(--color-success-light)', icon: CheckIcon }
+    if (status === 'failed') return { title: 'Payment Failed', color: 'var(--color-error)', bg: 'var(--color-error-light)', icon: XIcon }
+    return { title: 'Payment Processing', color: 'var(--color-warning)', bg: 'var(--color-warning-light)', icon: ClockIcon }
+  }, [status])
+
+  if (loading) {
+    return (
+      <div className="mx-auto w-full max-w-[560px] rounded-[var(--radius-lg)] bg-[var(--color-white)] p-[var(--space-8)] shadow-[var(--shadow-sm)]">
+        <div className="flex flex-col items-center gap-[var(--space-4)]">
+          <Skeleton variant="avatar" size="lg" />
+          <Skeleton variant="text" width={220} height={24} />
+          <Skeleton variant="text" width={180} height={34} />
+          <div className="w-full">
+            <Skeleton variant="text" width={320} />
+            <Skeleton variant="text" width={260} />
+            <Skeleton variant="text" width={300} />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center gap-[var(--space-6)]">
+        <Empty
+          variant="error-network"
+          title="Unable to load payment result"
+          description={error}
+          action={
+            <div className="flex gap-[var(--space-3)]">
+              <Button onClick={onRetryFetch}>Retry</Button>
+              <Button variant="ghost" onClick={onNavigateList}>
+                Back to Transactions
+              </Button>
+            </div>
+          }
+        />
+      </div>
+    )
+  }
+
+  if (!result) return null
+
+  const amountText = `${formatMoney(result.amountCents, result.currency)} ${result.currency}`
+  const infoRows = [
+    {
+      label: 'Transaction ID',
+      value: (
+        <span className="inline-flex items-center gap-2 font-mono text-[var(--color-gray-500)]">
+          {result.id}
+          <button
+            type="button"
+            onClick={() => onCopyId?.(result.id)}
+            className="flex items-center justify-center rounded-[var(--radius-sm)] p-1 text-[var(--color-gray-400)] hover:bg-[var(--color-gray-100)] hover:text-[var(--color-primary-600)]"
+            aria-label="Copy transaction ID"
+            title="Copy ID"
+          >
+            {CopyIcon}
+          </button>
+        </span>
+      ),
+    },
+    { label: 'Merchant', value: <span className="text-[var(--color-gray-700)]">{result.merchantName}</span> },
+    { label: 'Time', value: <span className="text-[var(--color-gray-500)]">{formatDateTime(result.createdAt)}</span> },
+  ]
+
+  const showSummary = result.status === 'success'
+  const showError = result.status === 'failed'
+
+  return (
+    <>
+      <style jsx>{`
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(4px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes scaleIn {
+          from { transform: scale(0.8); }
+          to { transform: scale(1); }
+        }
+        @keyframes shake {
+          0%, 100% { transform: translateX(0); }
+          25% { transform: translateX(-4px); }
+          75% { transform: translateX(4px); }
+        }
+        @keyframes spin1500 {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+      `}</style>
+
+      <div
+        className="mx-auto w-full max-w-[560px] rounded-[var(--radius-lg)] bg-[var(--color-white)] p-[var(--space-8)] text-center shadow-[var(--shadow-sm)]"
+        role="status"
+        aria-live="polite"
+      >
+        {/* Icon */}
+        <div
+          className="mx-auto flex h-20 w-20 items-center justify-center rounded-full"
+          style={{ backgroundColor: statusCfg.bg, animation: `fadeIn 300ms ease both` }}
+          aria-hidden="true"
+        >
+          <div
+            className="flex h-16 w-16 items-center justify-center rounded-full"
+            style={{
+              color: statusCfg.color,
+              animation:
+                status === 'success'
+                  ? `scaleIn 300ms ease both`
+                  : status === 'failed'
+                    ? `shake 200ms ease both`
+                    : `spin1500 1500ms linear infinite`,
+            }}
+          >
+            {statusCfg.icon}
+          </div>
+        </div>
+
+        {/* Title */}
+        <div
+          className="mt-[var(--space-4)] text-[var(--font-xl)] font-semibold"
+          style={{ color: statusCfg.color, animation: `fadeIn 300ms ease 100ms both` }}
+        >
+          {statusCfg.title}
+        </div>
+
+        {status === 'pending' && (
+          <div
+            className="mt-2 text-[var(--font-sm)] text-[var(--color-gray-500)]"
+            style={{ animation: `fadeIn 300ms ease 200ms both` }}
+          >
+            This may take a few moments...
+          </div>
+        )}
+
+        {/* Amount */}
+        <div
+          className="mt-[var(--space-2)] font-mono text-[var(--font-3xl)] font-bold text-[var(--color-gray-900)]"
+          style={{ animation: `fadeIn 300ms ease 200ms both` }}
+        >
+          {amountText}
+        </div>
+
+        {showError && result.error && (
+          <div
+            className="mt-[var(--space-6)] rounded-[var(--radius-md)] border border-[var(--color-error-light)] bg-[var(--color-error-light)] p-[var(--space-3)] text-left"
+            style={{ animation: `fadeIn 300ms ease 300ms both` }}
+          >
+            <div className="text-[var(--font-sm)] text-[var(--color-error)]">
+              Error: {result.error.message}
+            </div>
+            <div className="mt-1 font-mono text-[var(--font-xs)] text-[var(--color-gray-500)]">({result.error.code})</div>
+          </div>
+        )}
+
+        {/* Info */}
+        <div
+          className="mt-[var(--space-6)] flex flex-col gap-2 text-left"
+          style={{ animation: `fadeIn 300ms ease 300ms both` }}
+        >
+          {infoRows.map((r) => (
+            <div key={r.label} className="flex items-start justify-between gap-3">
+              <span className="text-[var(--font-sm)] text-[var(--color-gray-500)]">{r.label}:</span>
+              <span className="text-[var(--font-sm)] text-[var(--color-gray-700)]">{r.value}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Pending auto-refresh */}
+        {result.status === 'pending' && (
+          <div className="mt-[var(--space-4)] text-[var(--font-xs)] text-[var(--color-gray-500)]">
+            {timedOut ? (
+              <div className="flex flex-col items-center gap-2">
+                <div>Taking longer than expected.</div>
+                <Button variant="secondary" size="sm" onClick={onManualRefresh}>
+                  Refresh
+                </Button>
+              </div>
+            ) : (
+              <div aria-live="polite">Auto-refreshing in {countdownSeconds ?? 5}s...</div>
+            )}
+          </div>
+        )}
+
+        {/* Quick Summary */}
+        {showSummary && (
+          <>
+            <div className="my-[var(--space-6)] h-px w-full bg-[var(--color-gray-100)]" />
+            <div className="text-left">
+              <div className="text-[var(--font-sm)] font-medium uppercase tracking-[0.05em] text-[var(--color-gray-500)]">
+                Quick Summary
+              </div>
+              <div className="mt-[var(--space-3)]">
+                {[
+                  { label: 'Method', value: methodLabel(result) },
+                  { label: 'Reference', value: result.referenceId || '—' },
+                  { label: 'Fee', value: result.feeCents != null ? formatMoney(result.feeCents, result.currency) : '—' },
+                  {
+                    label: 'Net Amount',
+                    value: result.netCents != null ? formatMoney(result.netCents, result.currency) : '—',
+                    strong: true,
+                  },
+                ].map((r) => (
+                  <div
+                    key={r.label}
+                    className="flex h-9 items-center justify-between border-b border-[var(--color-gray-100)] last:border-0"
+                  >
+                    <span className="text-[var(--font-sm)] text-[var(--color-gray-500)]">{r.label}</span>
+                    <span
+                      className={[
+                        'text-[var(--font-sm)] text-[var(--color-gray-700)]',
+                        r.strong ? 'font-semibold text-[var(--color-gray-900)]' : '',
+                      ].join(' ')}
+                    >
+                      {r.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="mt-[var(--space-8)] flex flex-col items-stretch justify-center gap-[var(--space-3)] sm:flex-row">
+        {result.status === 'success' && (
+          <>
+            <Button onClick={() => onNavigateView?.(result.id)}>View Transaction</Button>
+            <Button variant="secondary" onClick={() => onNavigateNew?.({})}>
+              Create Another
+            </Button>
+            <Button variant="ghost" onClick={onNavigateList}>
+              ← List
+            </Button>
+          </>
+        )}
+        {result.status === 'failed' && (
+          <>
+            <Button onClick={() => onNavigateNew?.({ prefill: result.payload })}>Retry Payment</Button>
+            <Button variant="secondary" onClick={() => onNavigateView?.(result.id)}>
+              View Details
+            </Button>
+            <Button variant="ghost" onClick={onNavigateList}>
+              ← List
+            </Button>
+          </>
+        )}
+        {result.status === 'pending' && (
+          <>
+            <Button onClick={() => onNavigateView?.(result.id)}>View Transaction</Button>
+            <Button variant="ghost" onClick={onNavigateList}>
+              ← Back to List
+            </Button>
+          </>
+        )}
+      </div>
+    </>
+  )
+}
+
+export default PaymentResultCard

--- a/workspace/fe/src/components/business/transactions/PaymentReview.tsx
+++ b/workspace/fe/src/components/business/transactions/PaymentReview.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import { Button, Dialog } from '../../design'
+import type { CreatePaymentPayload, Merchant } from './types'
+
+export interface PaymentReviewProps {
+  value: CreatePaymentPayload
+  merchant: Merchant | null
+  disabled?: boolean
+  dirty?: boolean
+  onBack: () => void
+  onCancel: () => void
+  onConfirmCancel: () => void
+  cancelConfirmOpen: boolean
+  onSubmit: () => void
+  submitting?: boolean
+}
+
+const WarningIcon = (
+  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+  </svg>
+)
+
+const BackIcon = (
+  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+  </svg>
+)
+
+function maskCard(num: string) {
+  const digits = num.replace(/\D/g, '')
+  const last4 = digits.slice(-4)
+  return last4 ? `•••• ${last4}` : ''
+}
+
+export function PaymentReview({
+  value,
+  merchant,
+  disabled,
+  dirty,
+  onBack,
+  onCancel,
+  onConfirmCancel,
+  cancelConfirmOpen,
+  onSubmit,
+  submitting,
+}: PaymentReviewProps) {
+  const merchantLabel = merchant ? `${merchant.name} (${merchant.id})` : value.merchantId
+  const amount = (value.amountCents / 100).toFixed(2)
+
+  const rows: Array<{ label: string; value: string }> = [
+    { label: 'Merchant', value: merchantLabel },
+    { label: 'Amount', value: `${amount} ${value.currency}` },
+    { label: 'Reference', value: value.referenceId || '—' },
+    { label: 'Description', value: value.description || '—' },
+  ]
+
+  const methodRows: Array<{ label: string; value: string }> = [
+    {
+      label: 'Method',
+      value:
+        value.method === 'card'
+          ? 'Card'
+          : value.method === 'bank_transfer'
+            ? 'Bank Transfer'
+            : 'E-Wallet',
+    },
+  ]
+
+  if (value.method === 'card') {
+    methodRows.push({
+      label: 'Card',
+      value: `${maskCard(value.card?.number ?? '')}`,
+    })
+    methodRows.push({ label: 'Cardholder', value: value.card?.cardholder ?? '—' })
+  }
+
+  return (
+    <div className="flex flex-col gap-[var(--space-6)]">
+      <section className="rounded-[var(--radius-lg)] bg-[var(--color-white)] p-[var(--space-6)] shadow-[var(--shadow-sm)]">
+        <h2 className="mb-[var(--space-4)] text-[var(--font-xl)] font-semibold text-[var(--color-gray-900)]">
+          Review Payment
+        </h2>
+
+        <div className="text-[var(--font-sm)] font-medium uppercase tracking-[0.05em] text-[var(--color-gray-500)]">
+          Payment Summary
+        </div>
+        <div className="mt-[var(--space-3)] flex flex-col">
+          {rows.map((r) => (
+            <div
+              key={r.label}
+              className="flex h-9 items-center justify-between border-b border-[var(--color-gray-100)] last:border-0"
+            >
+              <span className="w-[40%] text-[var(--font-sm)] text-[var(--color-gray-500)]">{r.label}</span>
+              <span className="w-[60%] text-right text-[var(--font-sm)] text-[var(--color-gray-700)]">
+                {r.label === 'Amount' ? (
+                  <span className="text-[var(--font-lg)] font-semibold text-[var(--color-gray-900)]">
+                    {r.value}
+                  </span>
+                ) : (
+                  r.value
+                )}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <div className="my-[var(--space-6)] h-px w-full bg-[var(--color-gray-100)]" />
+
+        <div className="text-[var(--font-sm)] font-medium uppercase tracking-[0.05em] text-[var(--color-gray-500)]">
+          Payment Method
+        </div>
+        <div className="mt-[var(--space-3)] flex flex-col">
+          {methodRows.map((r) => (
+            <div
+              key={r.label}
+              className="flex h-9 items-center justify-between border-b border-[var(--color-gray-100)] last:border-0"
+            >
+              <span className="w-[40%] text-[var(--font-sm)] text-[var(--color-gray-500)]">{r.label}</span>
+              <span className="w-[60%] text-right text-[var(--font-sm)] text-[var(--color-gray-700)]">
+                {r.value}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {value.metadata.length > 0 && (
+          <>
+            <div className="my-[var(--space-6)] h-px w-full bg-[var(--color-gray-100)]" />
+            <div className="text-[var(--font-sm)] font-medium uppercase tracking-[0.05em] text-[var(--color-gray-500)]">
+              Metadata
+            </div>
+            <div className="mt-[var(--space-3)] flex flex-col">
+              {value.metadata.map((m) => (
+                <div
+                  key={m.key}
+                  className="flex h-9 items-center justify-between border-b border-[var(--color-gray-100)] last:border-0"
+                >
+                  <span className="w-[40%] text-[var(--font-sm)] text-[var(--color-gray-500)] font-mono">
+                    {m.key}
+                  </span>
+                  <span className="w-[60%] text-right text-[var(--font-sm)] text-[var(--color-gray-700)]">
+                    {m.value}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        <div
+          className="mt-[var(--space-6)] flex items-start gap-2 rounded-[var(--radius-md)] bg-[var(--color-warning-light)] p-[var(--space-3)] text-[var(--color-warning)]"
+          role="note"
+        >
+          <span className="mt-0.5" aria-hidden="true">
+            {WarningIcon}
+          </span>
+          <div className="text-[var(--font-sm)]">
+            Please verify the details before submitting.
+          </div>
+        </div>
+      </section>
+
+      <div className="flex flex-wrap justify-end gap-[var(--space-3)]">
+        <Button variant="ghost" icon={BackIcon} onClick={onBack} disabled={disabled || submitting}>
+          Back to Edit
+        </Button>
+        <Button variant="ghost" onClick={onCancel} disabled={disabled || submitting}>
+          Cancel
+        </Button>
+        <Button onClick={onSubmit} loading={!!submitting} disabled={disabled || submitting} aria-busy={submitting}>
+          Submit Payment
+        </Button>
+      </div>
+
+      <Dialog
+        open={cancelConfirmOpen}
+        onClose={onCancel}
+        variant="confirm"
+        title="Discard changes?"
+        footer={
+          <>
+            <Button variant="ghost" onClick={onCancel}>
+              Keep editing
+            </Button>
+            <Button variant="danger" onClick={onConfirmCancel}>
+              Discard
+            </Button>
+          </>
+        }
+      >
+        <div className="text-[var(--font-base)] text-[var(--color-text-secondary)]">
+          {dirty ? 'You have unsaved changes. Are you sure you want to discard them?' : 'Discard this payment draft?'}
+        </div>
+      </Dialog>
+    </div>
+  )
+}
+
+export default PaymentReview
+

--- a/workspace/fe/src/components/business/transactions/StepIndicator.tsx
+++ b/workspace/fe/src/components/business/transactions/StepIndicator.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+export interface Step {
+  key: string
+  label: ReactNode
+}
+
+export interface StepIndicatorProps {
+  steps: Step[]
+  /** 0-based current step index */
+  current: number
+  /** mark a step as completed (typically < current, but can be all completed on result page) */
+  completed?: boolean[]
+  className?: string
+}
+
+const CheckIcon = (
+  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+  </svg>
+)
+
+export function StepIndicator({ steps, current, completed, className = '' }: StepIndicatorProps) {
+  const completedFlags = completed ?? steps.map((_, i) => i < current)
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Form steps"
+      className={['flex items-center justify-center', 'mb-[var(--space-8)]', className].join(' ')}
+    >
+      <ol className="flex items-center">
+        {steps.map((s, idx) => {
+          const isCompleted = !!completedFlags[idx]
+          const isCurrent = idx === current
+          const isUpcoming = !isCompleted && !isCurrent
+
+          const circleCls = isCompleted
+            ? 'bg-[var(--color-success)] text-[var(--color-white)]'
+            : isCurrent
+              ? 'bg-[var(--color-primary-500)] text-[var(--color-white)]'
+              : 'bg-[var(--color-gray-200)] text-[var(--color-gray-500)]'
+
+          const connectorActive = idx < current || (completedFlags[idx] && !isCurrent)
+          const connectorCls = connectorActive
+            ? 'bg-[var(--color-primary-500)]'
+            : 'bg-[var(--color-gray-200)]'
+
+          return (
+            <li key={s.key} className="flex items-center">
+              <div className="flex flex-col items-center">
+                <div
+                  className={[
+                    'h-8 w-8 rounded-full flex items-center justify-center text-[var(--font-sm)] font-semibold',
+                    circleCls,
+                  ].join(' ')}
+                  aria-current={isCurrent ? 'step' : undefined}
+                >
+                  {isCompleted ? CheckIcon : idx + 1}
+                </div>
+                <div className="mt-[var(--space-2)] text-center text-[var(--font-sm)]">
+                  <div className={isUpcoming ? 'text-[var(--color-gray-500)]' : 'text-[var(--color-gray-700)]'}>
+                    {s.label}
+                  </div>
+                </div>
+              </div>
+
+              {idx < steps.length - 1 && (
+                <div
+                  className={['mx-3 h-[2px] w-20', connectorCls].join(' ')}
+                  aria-hidden="true"
+                />
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}
+
+export default StepIndicator
+

--- a/workspace/fe/src/components/business/transactions/types.ts
+++ b/workspace/fe/src/components/business/transactions/types.ts
@@ -49,3 +49,63 @@ export interface RefundRequest {
   reason: 'customer_request' | 'duplicate' | 'fraud' | 'other'
 }
 
+/* ── Create Payment / Result (P0-1) ── */
+export type PaymentMethod = 'card' | 'bank_transfer' | 'e_wallet'
+
+export interface Merchant {
+  id: string
+  name: string
+  /** max allowed amount for this merchant */
+  limitCents: number
+  /** currencies supported by merchant */
+  currencies: string[]
+  /** default currency for new payment */
+  defaultCurrency: string
+}
+
+export interface MetadataItem {
+  key: string
+  value: string
+}
+
+export interface CardDetails {
+  number: string
+  expiry: string // MM/YY
+  cvv: string
+  cardholder: string
+}
+
+export interface CreatePaymentPayload {
+  merchantId: string
+  amountCents: number
+  currency: string
+  referenceId: string
+  description: string
+  method: PaymentMethod
+  card?: CardDetails
+  metadata: MetadataItem[]
+}
+
+export type PaymentResultStatus = 'success' | 'failed' | 'pending'
+
+export interface PaymentErrorInfo {
+  message: string
+  code: string
+}
+
+export interface PaymentResult {
+  id: string
+  status: PaymentResultStatus
+  createdAt: string // ISO
+  merchantId: string
+  merchantName: string
+  amountCents: number
+  currency: string
+  method: PaymentMethod
+  referenceId: string
+  feeCents?: number
+  netCents?: number
+  error?: PaymentErrorInfo
+  /** used for Retry Payment (prefill) */
+  payload?: CreatePaymentPayload
+}

--- a/workspace/fe/src/hooks/useCreatePayment.ts
+++ b/workspace/fe/src/hooks/useCreatePayment.ts
@@ -1,0 +1,251 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import type { CreatePaymentPayload, Merchant } from '../components/business/transactions/types'
+import { createPayment, fetchMerchants } from '../services/transactions'
+
+export type CreatePaymentStep = 0 | 1
+
+export interface CreatePaymentFieldErrors {
+  merchantId?: string
+  amountCents?: string
+  currency?: string
+  method?: string
+  referenceId?: string
+  description?: string
+  'card.number'?: string
+  'card.expiry'?: string
+  'card.cvv'?: string
+  'card.cardholder'?: string
+  metadata?: string
+}
+
+function luhnCheck(num: string) {
+  const digits = num.replace(/\D/g, '')
+  if (digits.length < 12) return false
+  let sum = 0
+  let shouldDouble = false
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    let d = Number(digits[i])
+    if (shouldDouble) {
+      d *= 2
+      if (d > 9) d -= 9
+    }
+    sum += d
+    shouldDouble = !shouldDouble
+  }
+  return sum % 10 === 0
+}
+
+function isFutureExpiry(mmYY: string) {
+  const m = mmYY.match(/^(\d{2})\/(\d{2})$/)
+  if (!m) return false
+  const mm = Number(m[1])
+  const yy = Number(m[2])
+  if (mm < 1 || mm > 12) return false
+  const now = new Date()
+  const fullYear = 2000 + yy
+  // card valid through end of month
+  const exp = new Date(fullYear, mm, 0, 23, 59, 59, 999)
+  return exp.getTime() >= now.getTime()
+}
+
+function defaultPayload(): CreatePaymentPayload {
+  return {
+    merchantId: '',
+    amountCents: 0,
+    currency: 'USD',
+    referenceId: '',
+    description: '',
+    method: 'card',
+    card: { number: '', expiry: '', cvv: '', cardholder: '' },
+    metadata: [],
+  }
+}
+
+export function useCreatePayment() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const [step, setStep] = useState<CreatePaymentStep>(0)
+  const [value, setValue] = useState<CreatePaymentPayload>(defaultPayload())
+  const [errors, setErrors] = useState<CreatePaymentFieldErrors>({})
+  const [dirty, setDirty] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false)
+
+  /* ── Merchants ── */
+  const [merchants, setMerchants] = useState<Merchant[]>([])
+  const [merchantsLoading, setMerchantsLoading] = useState(true)
+  const [merchantsError, setMerchantsError] = useState<string | null>(null)
+
+  const loadMerchants = useCallback(async () => {
+    setMerchantsLoading(true)
+    setMerchantsError(null)
+    try {
+      const list = await fetchMerchants()
+      setMerchants(list)
+    } catch (e) {
+      setMerchantsError('Failed to load merchants')
+    } finally {
+      setMerchantsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadMerchants()
+  }, [loadMerchants])
+
+  /* ── Prefill (Retry Payment) ── */
+  useEffect(() => {
+    const prefill = searchParams.get('prefill')
+    if (prefill !== '1') return
+    try {
+      const raw = sessionStorage.getItem('createPaymentPrefill')
+      if (!raw) return
+      const data = JSON.parse(raw) as CreatePaymentPayload
+      setValue(data)
+      sessionStorage.removeItem('createPaymentPrefill')
+    } catch {
+      // ignore
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const merchant = useMemo(() => merchants.find((m) => m.id === value.merchantId) ?? null, [merchants, value.merchantId])
+
+  const validateAll = useCallback(
+    (v: CreatePaymentPayload): CreatePaymentFieldErrors => {
+      const next: CreatePaymentFieldErrors = {}
+
+      if (!v.merchantId) next.merchantId = 'Please select a merchant'
+
+      if (!v.currency) next.currency = 'Please select currency'
+
+      const amount = v.amountCents / 100
+      if (!v.amountCents || amount <= 0 || !Number.isFinite(amount)) {
+        next.amountCents = 'Enter a valid amount'
+      } else {
+        // max 2 decimals implied by cents
+        const limit = merchant?.limitCents
+        if (limit != null && v.amountCents > limit) {
+          next.amountCents = `Amount exceeds merchant limit (${(limit / 100).toFixed(2)} ${v.currency})`
+        }
+      }
+
+      if (!v.method) next.method = 'Please select a payment method'
+
+      if (v.method === 'card') {
+        const num = v.card?.number ?? ''
+        const exp = v.card?.expiry ?? ''
+        const cvv = v.card?.cvv ?? ''
+        const holder = v.card?.cardholder ?? ''
+
+        if (!num || !luhnCheck(num)) next['card.number'] = 'Invalid card number'
+        if (!exp || !isFutureExpiry(exp)) next['card.expiry'] = 'Card has expired'
+        if (!/^(\d{3,4})$/.test(cvv)) next['card.cvv'] = 'Invalid CVV'
+        if (!holder.trim()) next['card.cardholder'] = 'Enter cardholder name'
+      }
+
+      if (v.metadata.length > 0) {
+        const keys = v.metadata.map((m) => m.key.trim()).filter(Boolean)
+        const set = new Set<string>()
+        for (const k of keys) {
+          if (!/^[a-zA-Z0-9_]+$/.test(k)) {
+            next.metadata = 'Invalid key format'
+            break
+          }
+          if (set.has(k)) {
+            next.metadata = 'Duplicate key'
+            break
+          }
+          set.add(k)
+        }
+      }
+
+      return next
+    },
+    [merchant?.limitCents, merchant, value.currency],
+  )
+
+  const validateField = useCallback(
+    (field: string) => {
+      const all = validateAll(value)
+      if (field === 'metadata') {
+        setErrors((prev) => ({ ...prev, metadata: all.metadata }))
+        return
+      }
+      setErrors((prev) => ({ ...prev, [field]: (all as any)[field] }))
+    },
+    [validateAll, value],
+  )
+
+  const setNextValue = useCallback((next: CreatePaymentPayload) => {
+    setValue(next)
+    setDirty(true)
+    // clear errors while typing (keep other fields)
+  }, [])
+
+  const openCancel = useCallback(() => {
+    if (dirty) setCancelConfirmOpen(true)
+    else router.push('/transactions')
+  }, [dirty, router])
+
+  const closeCancel = useCallback(() => setCancelConfirmOpen(false), [])
+
+  const confirmCancel = useCallback(() => {
+    setCancelConfirmOpen(false)
+    router.push('/transactions')
+  }, [router])
+
+  const continueToReview = useCallback(() => {
+    const nextErrors = validateAll(value)
+    setErrors(nextErrors)
+    if (Object.values(nextErrors).some(Boolean)) return
+    setStep(1)
+  }, [validateAll, value])
+
+  const backToEdit = useCallback(() => setStep(0), [])
+
+  const submit = useCallback(async () => {
+    const nextErrors = validateAll(value)
+    setErrors(nextErrors)
+    if (Object.values(nextErrors).some(Boolean)) return
+    setSubmitting(true)
+    try {
+      const res = await createPayment(value)
+      setDirty(false)
+      router.push(`/transactions/${encodeURIComponent(res.id)}/result`)
+    } finally {
+      setSubmitting(false)
+    }
+  }, [router, validateAll, value])
+
+  return {
+    step,
+    setStep,
+    value,
+    setValue: setNextValue,
+    merchant,
+    merchants,
+    merchantsLoading,
+    merchantsError,
+    retryMerchants: loadMerchants,
+    errors,
+    validateField,
+    validateAll,
+    dirty,
+    submitting,
+    cancelConfirmOpen,
+    openCancel,
+    closeCancel,
+    confirmCancel,
+    continueToReview,
+    backToEdit,
+    submit,
+  }
+}
+
+export default useCreatePayment
+

--- a/workspace/fe/src/hooks/usePaymentResult.ts
+++ b/workspace/fe/src/hooks/usePaymentResult.ts
@@ -1,0 +1,122 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { PaymentResult } from '../components/business/transactions/types'
+import { fetchPaymentResult } from '../services/transactions'
+
+export interface UsePaymentResultOptions {
+  id: string
+}
+
+export function usePaymentResult({ id }: UsePaymentResultOptions) {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<PaymentResult | null>(null)
+
+  const [attempts, setAttempts] = useState(0)
+  const maxAttempts = 12
+  const intervalMs = 5000
+
+  const [countdownSeconds, setCountdownSeconds] = useState(5)
+  const [timedOut, setTimedOut] = useState(false)
+
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const tickTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const attemptsRef = useRef(0)
+
+  const stopTimers = useCallback(() => {
+    if (pollTimerRef.current) window.clearInterval(pollTimerRef.current)
+    if (tickTimerRef.current) window.clearInterval(tickTimerRef.current)
+    pollTimerRef.current = null
+    tickTimerRef.current = null
+  }, [])
+
+  const fetchOnce = useCallback(async () => {
+    if (!id) return
+    setLoading(true)
+    setError(null)
+    try {
+      const r = await fetchPaymentResult(id)
+      if (!r) {
+        router.push('/transactions')
+        return
+      }
+      setResult(r)
+    } catch (e) {
+      setError('Unable to load payment result')
+    } finally {
+      setLoading(false)
+    }
+  }, [id, router])
+
+  const startPolling = useCallback(() => {
+    stopTimers()
+    attemptsRef.current = 0
+    setAttempts(0)
+    setTimedOut(false)
+    setCountdownSeconds(Math.ceil(intervalMs / 1000))
+
+    tickTimerRef.current = window.setInterval(() => {
+      setCountdownSeconds((s) => (s <= 1 ? Math.ceil(intervalMs / 1000) : s - 1))
+    }, 1000)
+
+    pollTimerRef.current = window.setInterval(async () => {
+      attemptsRef.current += 1
+      setAttempts(attemptsRef.current)
+      if (attemptsRef.current > maxAttempts) {
+        stopTimers()
+        setTimedOut(true)
+        return
+      }
+      try {
+        const r = await fetchPaymentResult(id)
+        if (!r) return
+        setResult(r)
+        if (r.status !== 'pending') {
+          stopTimers()
+        }
+      } catch {
+        // ignore transient
+      }
+    }, intervalMs)
+  }, [id, stopTimers])
+
+  useEffect(() => {
+    void fetchOnce()
+  }, [fetchOnce])
+
+  useEffect(() => {
+    if (!result || result.status !== 'pending') {
+      stopTimers()
+      return
+    }
+    startPolling()
+    return () => stopTimers()
+  }, [result?.status, startPolling, stopTimers])
+
+  const manualRefresh = useCallback(async () => {
+    setTimedOut(false)
+    attemptsRef.current = 0
+    setAttempts(0)
+    setCountdownSeconds(Math.ceil(intervalMs / 1000))
+    await fetchOnce()
+    if (result?.status === 'pending') startPolling()
+  }, [fetchOnce, result?.status, startPolling])
+
+  const canPoll = useMemo(() => result?.status === 'pending' && !timedOut, [result?.status, timedOut])
+
+  return {
+    loading,
+    error,
+    result,
+    countdownSeconds,
+    timedOut,
+    canPoll,
+    retry: fetchOnce,
+    manualRefresh,
+  }
+}
+
+export default usePaymentResult


### PR DESCRIPTION
## P0-1 Create Payment + Result 实现

### 设计基线
- specs/hifi/transactions-create.md (3步表单)
- specs/hifi/transactions-result.md (3态结果页)
- v3-tokens.md v0.1.1

### 交付内容
- /transactions/new — 3步创建支付表单
  - Step 1: Merchant搜索 + Amount复合输入 + PaymentMethod条件渲染 + Metadata动态行
  - Step 2: Review确认 + Back/Cancel语义区分
  - Step 3: Submit → redirect to Result
- /transactions/:id/result — 支付结果页
  - Success: 入场动画 + Quick Summary + 3按钮
  - Failed: Error info + Retry(预填) + 2按钮
  - Pending: Auto-poll 5s/60s + countdown + 状态转换动画
- 新增组件: StepIndicator, PaymentForm, PaymentReview, PaymentResult
- Mock: createPayment (随机结果) + fetchPaymentResult (pending自动转换)
- 更新: /transactions 列表页新增 Create Payment 入口按钮

### QA 建议项处理
- Browser back 行为 → 简化为直接回列表 (QA P2建议)
- Pending 指数退避 → P1 (QA Enhancement建议)

### Accessibility
- form aria-label + aria-required + aria-invalid + aria-describedby
- Step indicator role=navigation + aria-current=step
- Result role=status + aria-live=polite
- inputmode=numeric for card/cvv
- focus trap on cancel dialog

Closes #8